### PR TITLE
Use PL_ prefix for environment variables

### DIFF
--- a/lib/api/config.js
+++ b/lib/api/config.js
@@ -1,2 +1,2 @@
 
-exports.API_URL = process.env.API_URL || 'https://api.planet.com/v0/';
+exports.API_URL = process.env.PL_API_URL || 'https://api.planet.com/v0/';


### PR DESCRIPTION
For consistency, let's use `PL_` prefixed environment variables.
