### PR TITLE
More useful debug output for failing downloads

### DIFF
--- a/lib/api/request.js
+++ b/lib/api/request.js
@@ -97,7 +97,7 @@ function parseConfig(config) {
 function createResponseHandler(resolve, reject, info) {
   return function(response) {
     var status = response.statusCode;
-    if (response.statusCode === 302) {
+    if (status === 302) {
       log.debug('Following redirect: ', response.headers.location);
       https.get(response.headers.location,
           createResponseHandler(resolve, reject, info));

--- a/lib/api/request.js
+++ b/lib/api/request.js
@@ -96,13 +96,20 @@ function parseConfig(config) {
  */
 function createResponseHandler(resolve, reject, info) {
   return function(response) {
+    var status = response.statusCode;
     if (response.statusCode === 302) {
+      log.debug('Following redirect: ', response.headers.location);
       https.get(response.headers.location,
           createResponseHandler(resolve, reject, info));
       return;
     }
     if (info.stream) {
-      resolve(response);
+      if (!(status >= 200 && status < 300)) {
+        reject(new errors.UnexpectedResponse('Unexpected response status: ' +
+            status, response));
+      } else {
+        resolve(response);
+      }
       return;
     }
     var body = '';
@@ -130,7 +137,6 @@ function createResponseHandler(resolve, reject, info) {
                 parseErr.stack + '\n', response, body);
           }
         }
-        var status = response.statusCode;
         if (status === 401) {
           err = new errors.Unauthorized('Unauthorized', response, body);
 

--- a/lib/cli/download-scenes.js
+++ b/lib/cli/download-scenes.js
@@ -6,6 +6,7 @@ var Batch = require('batch');
 var bole = require('bole');
 
 var addQueryParams = require('../api/util').addQueryParams;
+var errors = require('../api/errors');
 var request = require('../api/request');
 var util = require('./util');
 
@@ -70,6 +71,9 @@ function download(productUrl, directory) {
         var match;
         if (disposition) {
           match = disposition.match(FILENAME_RE);
+        } else {
+          log.warn('Expected content-disposition header for %s: %j %d',
+              productUrl, response.headers, response.statusCode);
         }
         var output;
         if (match) {
@@ -90,7 +94,18 @@ function download(productUrl, directory) {
         response.pipe(stream);
       })
       .catch(function(err) {
-        done(new Error('Request failed: ' + err.message));
+        if (err instanceof errors.ResponseError) {
+          if (err.body) {
+            log.debug('Response error downloading %s: status %d body %s',
+                productUrl, err.response.statusCode, err.body);
+          } else {
+            log.debug('Response error downloading %s: status %d',
+                productUrl, err.response.statusCode);
+          }
+        } else {
+          log.debug('Unexpected error: ', err);
+        }
+        done(new Error('Request for ' + productUrl + ' failed: ' + err.message));
       });
   };
 }


### PR DESCRIPTION
This generates more useful error messages when a download fails.  E.g:

```
error planet: Request for https://view.planet.com/v0/scenes/landsat/LC80390282015029LGN00/thumb?size=lg&format=png failed: Unexpected response status: 503
```

When running with `--log-level debug` additional information is available (about redirects followed, missing content-disposition headers, and unexpected response status).
