### PR TITLE
Consistent response wrapping

### DIFF
--- a/api/mosaics.js
+++ b/api/mosaics.js
@@ -15,8 +15,8 @@ var urls = require('./urls');
  */
 function get(id) {
   var url = urls.join(urls.MOSAICS, id);
-  return request.get(url).then(function(obj) {
-    return obj.data;
+  return request.get(url).then(function(res) {
+    return res.body;
   });
 }
 
@@ -31,8 +31,8 @@ function search(query) {
     url: urls.MOSAICS,
     query: query
   };
-  return request.get(config).then(function(obj) {
-    return new Page(obj.data, search);
+  return request.get(config).then(function(res) {
+    return new Page(res.body, search);
   });
 }
 

--- a/api/quads.js
+++ b/api/quads.js
@@ -16,8 +16,8 @@ var urls = require('./urls');
  */
 function get(mosaicId, quadId) {
   var url = urls.join(urls.MOSAICS, mosaicId, 'quads', quadId);
-  return request.get(url).then(function(obj) {
-    return obj.data;
+  return request.get(url).then(function(res) {
+    return res.body;
   });
 }
 
@@ -33,8 +33,8 @@ function search(mosaicId, query) {
     url: urls.join(urls.MOSAICS, mosaicId, 'quads', ''),
     query: query
   };
-  return request.get(config).then(function(obj) {
-    return new Page(obj.data, search.bind(null, mosaicId));
+  return request.get(config).then(function(res) {
+    return new Page(res.body, search.bind(null, mosaicId));
   });
 }
 

--- a/api/scenes.js
+++ b/api/scenes.js
@@ -25,11 +25,11 @@ function get(scene, options) {
     };
   }
   var url = urls.join(urls.SCENES, scene.type, scene.id);
-  return request.get(url).then(function(obj) {
+  return request.get(url).then(function(res) {
     if (options.augmentLinks !== false) {
-      util.augmentSceneLinks(obj.data);
+      util.augmentSceneLinks(res.body);
     }
-    return obj.data;
+    return res.body;
   });
 }
 
@@ -53,14 +53,14 @@ function search(query, options) {
     url: urls.join(urls.SCENES, type, ''),
     query: query
   };
-  return request.get(config).then(function(obj) {
+  return request.get(config).then(function(res) {
     if (options.augmentLinks !== false) {
-      var scenes = obj.data.features;
+      var scenes = res.body.features;
       for (var i = 0, ii = scenes.length; i < ii; ++i) {
         util.augmentSceneLinks(scenes[i]);
       }
     }
-    return new Page(obj.data, search);
+    return new Page(res.body, search);
   });
 }
 

--- a/api/workspaces.js
+++ b/api/workspaces.js
@@ -9,15 +9,15 @@ var urls = require('./urls');
 
 function get(id) {
   var url = urls.join(urls.WORKSPACES, id);
-  return request.get(url).then(function(obj) {
-    return obj.data;
+  return request.get(url).then(function(res) {
+    return res.body;
   });
 }
 
 function search() {
   var url = urls.WORKSPACES;
-  return request.get(url).then(function(obj) {
-    return obj.data;
+  return request.get(url).then(function(res) {
+    return res.body;
   });
 }
 

--- a/cli/download-scenes.js
+++ b/cli/download-scenes.js
@@ -64,7 +64,8 @@ function download(productUrl, directory) {
   return function(done) {
     log.debug('getting %s', productUrl);
     request.get({url: productUrl, stream: true})
-      .then(function(response) {
+      .then(function(res) {
+        var response = res.response;
         response.on('error', done);
         response.on('end', done);
         var disposition = response.headers['content-disposition'];

--- a/cli/find-scenes.js
+++ b/cli/find-scenes.js
@@ -113,9 +113,12 @@ function resolveQuery(opts) {
   return resolveIntersects(opts.intersects).then(function(geom) {
     var query = {
       type: opts.type,
-      intersects: geom,
       count: Math.min(opts.limit, 500)
     };
+
+    if (geom) {
+      query.intersects = geom;
+    }
 
     if (opts.acquired) {
       parseAcquired(opts.acquired, query);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "pretest": "eslint bin examples api cli test",
     "test": "mocha --recursive test",
+    "test-debug": "mocha --debug-brk --recursive test",
     "start": "watchy --watch bin,examples,api,cli,test -- npm test",
     "postpublish": "npm run publish-doc",
     "doc": "jsdoc --configure doc/config.json",

--- a/test/api/request.test.js
+++ b/test/api/request.test.js
@@ -123,13 +123,15 @@ describe('request', function() {
     it('rejects for invalid JSON in successful response', function(done) {
       var response = new stream.Readable();
       response.statusCode = 200;
+      var body = 'garbage response body';
 
       var promise = request({url: 'http://example.com'});
       promise.then(function(obj) {
         done(new Error('Expected promise to be rejected'));
       }, function(err) {
-        assert.instanceOf(err, Error);
+        assert.instanceOf(err, errors.UnexpectedResponse);
         assert.include(err.message, 'Trouble parsing response body as JSON');
+        assert.equal(err.body, body);
         done();
       }).catch(done);
 
@@ -138,7 +140,7 @@ describe('request', function() {
       assert.lengthOf(args, 2);
       var callback = args[1];
       callback(response);
-      response.emit('data', 'garbage in response body');
+      response.emit('data', body);
       response.emit('end');
     });
 

--- a/test/api/request.test.js
+++ b/test/api/request.test.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 var http = require('http');
 var https = require('https');
+var stream = require('stream');
 
 var chai = require('chai');
 var sinon = require('sinon');
@@ -68,6 +69,77 @@ describe('request', function() {
     it('uses https.request() for https URLs', function() {
       request({url: 'https://example.com'});
       assert.equal(https.request.callCount, 1);
+    });
+
+    it('resolves to an object with body and response', function(done) {
+      var response = new stream.Readable();
+      response.statusCode = 200;
+      var body = {
+        foo: 'bar'
+      };
+
+      var promise = request({url: 'http://example.com'});
+      promise.then(function(obj) {
+        assert.equal(obj.response, response);
+        assert.deepEqual(obj.body, body);
+        done();
+      }, done);
+
+      assert.equal(http.request.callCount, 1);
+      var args = http.request.getCall(0).args;
+      assert.lengthOf(args, 2);
+      var callback = args[1];
+      callback(response);
+      response.emit('data', JSON.stringify(body));
+      response.emit('end');
+    });
+
+    it('resolves before parsing body if stream is true', function(done) {
+      var response = new stream.Readable();
+      response.statusCode = 200;
+      var body = {
+        foo: 'bar'
+      };
+
+      var promise = request({
+        url: 'http://example.com',
+        stream: true
+      });
+      promise.then(function(obj) {
+        assert.equal(obj.response, response);
+        assert.isNull(obj.body);
+        done();
+      }, done);
+
+      assert.equal(http.request.callCount, 1);
+      var args = http.request.getCall(0).args;
+      assert.lengthOf(args, 2);
+      var callback = args[1];
+      callback(response);
+      response.emit('data', JSON.stringify(body));
+      response.emit('end');
+    });
+
+    it('rejects for invalid JSON in successful response', function(done) {
+      var response = new stream.Readable();
+      response.statusCode = 200;
+
+      var promise = request({url: 'http://example.com'});
+      promise.then(function(obj) {
+        done(new Error('Expected promise to be rejected'));
+      }, function(err) {
+        assert.instanceOf(err, Error);
+        assert.include(err.message, 'Trouble parsing response body as JSON');
+        done();
+      }).catch(done);
+
+      assert.equal(http.request.callCount, 1);
+      var args = http.request.getCall(0).args;
+      assert.lengthOf(args, 2);
+      var callback = args[1];
+      callback(response);
+      response.emit('data', 'garbage in response body');
+      response.emit('end');
     });
 
     it('accepts a terminator for aborting requests', function(done) {


### PR DESCRIPTION
The request method now returns a promise that resolves to an object with `response` and `body` properties.
- if the response is in the 2xx range, `body` is the `JSON.parse`d response body
- if the the body is not valid JSON, the promise will be rejected with an `UnexpectedResponse` error
- if the request `stream` option is true, the `body` will be `null`
