### PR TITLE
Preserve pathname when appending query

### DIFF
--- a/api/request.js
+++ b/api/request.js
@@ -32,7 +32,7 @@ function parseConfig(config) {
   var base = config.url ? url.parse(config.url, true) : {query: {}};
   if (config.query) {
     config.path = url.format({
-      pathname: base.pathname || '/',
+      pathname: base.pathname || config.pathname || '/',
       query: assign(base.query, config.query)
     });
   }

--- a/test/api/request.test.js
+++ b/test/api/request.test.js
@@ -227,7 +227,7 @@ describe('request', function() {
     });
 
     it('works with a url.parse() response', function() {
-      var config = url.parse('https://example.com', true);
+      var config = url.parse('https://example.com/page/1', true);
       config.query.foo = 'bar';
 
       var options = {
@@ -235,7 +235,7 @@ describe('request', function() {
         hostname: 'example.com',
         port: '443',
         method: 'GET',
-        path: '/?foo=bar',
+        path: '/page/1?foo=bar',
         headers: defaultHeaders
       };
 


### PR DESCRIPTION
When passed the result of `url.parse()`, we need to respect the original pathname.
