### PR TITLE
Provide access to request terminator

### DIFF
--- a/api/page.js
+++ b/api/page.js
@@ -20,21 +20,23 @@ function Page(data, factory) {
   /**
    * Get the previous page.  If there is no previous page, `previous` will be
    *     `null`.
+   * @param {Object} options Any request options.
    * @return {Promise.<Page>} The previous page.
    * @method
    */
-  this.prev = !links.prev ? null : function() {
-    return factory(url.parse(links.prev, true).query);
+  this.prev = !links.prev ? null : function(options) {
+    return factory(url.parse(links.prev, true).query, options);
   };
 
   /**
    * Get the next page.
+   * @param {Object} options Any request options.
    * @return {Promise.<Page>} The next page.  If there is no next page,
    *     `next` will be `null`.
    * @method
    */
-  this.next = !links.next ? null : function() {
-    return factory(url.parse(links.next, true).query);
+  this.next = !links.next ? null : function(options) {
+    return factory(url.parse(links.next, true).query, options);
   };
 
   this.data = data;

--- a/api/quads.js
+++ b/api/quads.js
@@ -11,12 +11,19 @@ var urls = require('./urls');
  * Get metadata for a mosaic quad.
  * @param {string} mosaicId A mosaic identifier.
  * @param {string} quadId A quad identifier.
+ * @param {Object} options Options.
+ * @param {function(function())} options.terminator A function that is called
+ *     with a function that can be called back to terminate the request.
  * @return {Promise.<Object>} A promise that resolves to quad metadata or is
  *     rejected with any error.
  */
-function get(mosaicId, quadId) {
-  var url = urls.join(urls.MOSAICS, mosaicId, 'quads', quadId);
-  return request.get(url).then(function(res) {
+function get(mosaicId, quadId, options) {
+  options = options || {};
+  var config = {
+    url: urls.join(urls.MOSAICS, mosaicId, 'quads', quadId),
+    terminator: options.terminator
+  };
+  return request.get(config).then(function(res) {
     return res.body;
   });
 }
@@ -25,13 +32,18 @@ function get(mosaicId, quadId) {
  * Get a collection of quad metadata based on a query.
  * @param {string} mosaicId A mosaic identifier.
  * @param {Object} query A query object.
+ * @param {Object} options Options.
+ * @param {function(function())} options.terminator A function that is called
+ *     with a function that can be called back to terminate the request.
  * @return {Promise.<Page>} A promise that resolves to a page of quad
  *     metadata or is rejected with any error.
  */
-function search(mosaicId, query) {
+function search(mosaicId, query, options) {
+  options = options || {};
   var config = {
     url: urls.join(urls.MOSAICS, mosaicId, 'quads', ''),
-    query: query
+    query: query,
+    terminator: options.terminator
   };
   return request.get(config).then(function(res) {
     return new Page(res.body, search.bind(null, mosaicId));

--- a/api/scenes.js
+++ b/api/scenes.js
@@ -16,6 +16,8 @@ var util = require('./util');
  * @param {Object} options Options.
  * @param {boolean} options.augmentLinks Add API key to links for image
  *     resources in the response.  False by default.
+ * @param {function(function())} options.terminator A function that is called
+ *     with a function that can be called back to terminate the request.
  * @return {Promise.<Object>} A promise that resolves to scene metadata or is
  *     rejected with any error.
  */
@@ -27,8 +29,11 @@ function get(scene, options) {
       type: 'ortho'
     };
   }
-  var url = urls.join(urls.SCENES, scene.type, scene.id);
-  return request.get(url).then(function(res) {
+  var config = {
+    url: urls.join(urls.SCENES, scene.type, scene.id),
+    terminator: options.terminator
+  };
+  return request.get(config).then(function(res) {
     if (options.augmentLinks !== false) {
       util.augmentSceneLinks(res.body);
     }
@@ -42,6 +47,8 @@ function get(scene, options) {
  * @param {Object} options Options.
  * @param {boolean} options.augmentLinks Add API key to links for image
  *     resources in the response.  False by default.
+ * @param {function(function())} options.terminator A function that is called
+ *     with a function that can be called back to terminate the request.
  * @return {Promise.<Page>} A promise that resolves to a page of scene
  *     metadata or is rejected with any error.
  */
@@ -57,7 +64,8 @@ function search(query, options) {
 
   var config = {
     url: urls.join(urls.SCENES, type, ''),
-    query: query
+    query: query,
+    terminator: options.terminator
   };
   return request.get(config).then(function(res) {
     if (options.augmentLinks !== false) {

--- a/test/api/page.test.js
+++ b/test/api/page.test.js
@@ -1,0 +1,78 @@
+/* eslint-env mocha */
+var url = require('url');
+
+var assert = require('chai').assert;
+var sinon = require('sinon');
+
+var Page = require('../../api/page');
+
+describe('Page', function() {
+
+  var spy;
+  beforeEach(function() {
+    spy = sinon.spy();
+  });
+
+  describe('constructor', function() {
+
+    it('creates a new page given data and a factory function', function() {
+      var page = new Page({links: {}}, spy);
+      assert.instanceOf(page, Page);
+    });
+
+  });
+
+  describe('#data', function() {
+
+    it('provides access to page data', function() {
+      var data = {links: {}};
+      var page = new Page(data, spy);
+      assert.deepEqual(page.data, data);
+    });
+
+  });
+
+  describe('#next()', function() {
+
+    it('calls the factory with a query from the next url', function() {
+      var query = {
+        foo: 'bar',
+        num: '42'
+      };
+
+      var data = {
+        links: {
+          next: url.format({
+            query: query
+          })
+        }
+      };
+
+      var page = new Page(data, spy);
+      assert.typeOf(page.next, 'function');
+      page.next();
+      assert.equal(spy.callCount, 1);
+      var call = spy.getCall(0);
+      assert.deepEqual(call.args[0], query);
+    });
+
+    it('passes along options as second arg to factory', function() {
+      var data = {
+        links: {
+          next: 'http://example.com'
+        }
+      };
+
+      var page = new Page(data, spy);
+      assert.typeOf(page.next, 'function');
+
+      var options = {};
+      page.next(options);
+      assert.equal(spy.callCount, 1);
+      var call = spy.getCall(0);
+      assert.equal(call.args[1], options);
+    });
+
+  });
+
+});


### PR DESCRIPTION
This allows clients to terminate requests.

A timeout would be implemented like this:

``` js
var promise = api.scenes.search(query, {
  terminator: function(abort) {
    setTimeout(abort, 2000);
  }
});
```

The same options can be passed to `next` and `previous` methods of a resolved page.  E.g.

``` js
api.scenes.search(query).then(function(page) {
  if (page.next) {
    var promise = page.next({
      terminator: function(abort) {
        setTimeout(abort, 2000);
      }
    });
  }
});
```
