### PR TITLE
Optionally add API key to image resource links

### DIFF
--- a/api/mosaics.js
+++ b/api/mosaics.js
@@ -6,16 +6,29 @@
 var Page = require('./page');
 var request = require('./request');
 var urls = require('./urls');
+var util = require('./util');
 
 /**
  * Get metadata for a single mosaic.
  * @param {string} id A mosaic identifier.
+ * @param {Object} options Options.
+ * @param {boolean} options.augmentLinks Add API key to links for image
+ *     resources in the response.  True by default.
+ * @param {function(function())} options.terminator A function that is called
+ *     with a function that can be called back to terminate the request.
  * @return {Promise.<Object>} A promise that resolves to mosaic metadata or is
  *     rejected with any error.
  */
-function get(id) {
-  var url = urls.join(urls.MOSAICS, id);
-  return request.get(url).then(function(res) {
+function get(id, options) {
+  options = options || {};
+  var config = {
+    url: urls.join(urls.MOSAICS, id),
+    terminator: options.terminator
+  };
+  return request.get(config).then(function(res) {
+    if (options.augmentLinks !== false) {
+      util.augmentMosaicLinks(res.body);
+    }
     return res.body;
   });
 }
@@ -23,15 +36,28 @@ function get(id) {
 /**
  * Get a collection of mosaic metadata.
  * @param {Object} query A query object.
+ * @param {Object} options Options.
+ * @param {boolean} options.augmentLinks Add API key to links for image
+ *     resources in the response.  True by default.
+ * @param {function(function())} options.terminator A function that is called
+ *     with a function that can be called back to terminate the request.
  * @return {Promise.<Page>} A promise that resolves to a page of mosaic
  *     metadata or is rejected with any error.
  */
-function search(query) {
+function search(query, options) {
+  options = options || {};
   var config = {
     url: urls.MOSAICS,
-    query: query
+    query: query,
+    terminator: options.terminator
   };
   return request.get(config).then(function(res) {
+    if (options.augmentLinks !== false) {
+      var mosaics = res.body.mosaics;
+      for (var i = 0, ii = mosaics.length; i < ii; ++i) {
+        util.augmentMosaicLinks(mosaics[i]);
+      }
+    }
     return new Page(res.body, search);
   });
 }

--- a/api/quads.js
+++ b/api/quads.js
@@ -6,12 +6,15 @@
 var Page = require('./page');
 var request = require('./request');
 var urls = require('./urls');
+var util = require('./util');
 
 /**
  * Get metadata for a mosaic quad.
  * @param {string} mosaicId A mosaic identifier.
  * @param {string} quadId A quad identifier.
  * @param {Object} options Options.
+ * @param {boolean} options.augmentLinks Add API key to links for image
+ *     resources in the response.  True by default.
  * @param {function(function())} options.terminator A function that is called
  *     with a function that can be called back to terminate the request.
  * @return {Promise.<Object>} A promise that resolves to quad metadata or is
@@ -24,6 +27,9 @@ function get(mosaicId, quadId, options) {
     terminator: options.terminator
   };
   return request.get(config).then(function(res) {
+    if (options.augmentLinks !== false) {
+      util.augmentQuadLinks(res.body);
+    }
     return res.body;
   });
 }
@@ -33,6 +39,8 @@ function get(mosaicId, quadId, options) {
  * @param {string} mosaicId A mosaic identifier.
  * @param {Object} query A query object.
  * @param {Object} options Options.
+ * @param {boolean} options.augmentLinks Add API key to links for image
+ *     resources in the response.  True by default.
  * @param {function(function())} options.terminator A function that is called
  *     with a function that can be called back to terminate the request.
  * @return {Promise.<Page>} A promise that resolves to a page of quad
@@ -46,9 +54,45 @@ function search(mosaicId, query, options) {
     terminator: options.terminator
   };
   return request.get(config).then(function(res) {
+    if (options.augmentLinks !== false) {
+      var quads = res.body.features;
+      for (var i = 0, ii = quads.length; i < ii; ++i) {
+        util.augmentQuadLinks(quads[i]);
+      }
+    }
     return new Page(res.body, search.bind(null, mosaicId));
+  });
+}
+
+/**
+ * Get scenes for a mosaic quad.
+ * @param {string} mosaicId A mosaic identifier.
+ * @param {string} quadId A quad identifier.
+ * @param {Object} options Options.
+ * @param {boolean} options.augmentLinks Add API key to links for image
+ *     resources in the response.  True by default.
+ * @param {function(function())} options.terminator A function that is called
+ *     with a function that can be called back to terminate the request.
+ * @return {Promise.<Object>} A promise that resolves to quad metadata or is
+ *     rejected with any error.
+ */
+function scenes(mosaicId, quadId, options) {
+  options = options || {};
+  var config = {
+    url: urls.join(urls.MOSAICS, mosaicId, 'quads', quadId, 'scenes', ''),
+    terminator: options.terminator
+  };
+  return request.get(config).then(function(res) {
+    if (options.augmentLinks !== false) {
+      var features = res.body.features;
+      for (var i = 0, ii = features.length; i < ii; ++i) {
+        util.augmentSceneLinks(features[i]);
+      }
+    }
+    return res.body;
   });
 }
 
 exports.search = search;
 exports.get = get;
+exports.scenes = scenes;

--- a/api/scenes.js
+++ b/api/scenes.js
@@ -15,7 +15,7 @@ var util = require('./util');
  *     set to 'ortho'.
  * @param {Object} options Options.
  * @param {boolean} options.augmentLinks Add API key to links for image
- *     resources in the response.  False by default.
+ *     resources in the response.  True by default.
  * @param {function(function())} options.terminator A function that is called
  *     with a function that can be called back to terminate the request.
  * @return {Promise.<Object>} A promise that resolves to scene metadata or is
@@ -46,7 +46,7 @@ function get(scene, options) {
  * @param {Object} query A query object.
  * @param {Object} options Options.
  * @param {boolean} options.augmentLinks Add API key to links for image
- *     resources in the response.  False by default.
+ *     resources in the response.  True by default.
  * @param {function(function())} options.terminator A function that is called
  *     with a function that can be called back to terminate the request.
  * @return {Promise.<Page>} A promise that resolves to a page of scene


### PR DESCRIPTION
This adds any stored API key to mosaic, quad, and scene image resource URLs.
