### PR TITLE
Pass page options to next and prev

### DIFF
--- a/api/mosaics.js
+++ b/api/mosaics.js
@@ -48,7 +48,7 @@ function search(query, options) {
     terminator: options.terminator
   };
   return request.get(config).then(function(res) {
-    return new Page(res.body, search);
+    return new Page(res.body, search, options);
   });
 }
 

--- a/api/page.js
+++ b/api/page.js
@@ -11,30 +11,29 @@ var url = require('url');
  * @param {Object} data Data with optional prev and next links.
  * @param {function(Object):Promise} factory Function that creates a promise of
  *     new data given a query object.
+ * @param {Object} options Query options.
  * @constructor
  * @ignore
  */
-function Page(data, factory) {
+function Page(data, factory, options) {
   var links = data.links;
 
   /**
    * Get the previous page.  If there is no previous page, `prev` will be
    * `null`.
-   * @param {Object} options Any request options.
    * @return {Promise.<module:planet-client/api/page~Page>} The previous page.
    * @method
    */
-  this.prev = !links.prev ? null : function(options) {
+  this.prev = !links.prev ? null : function() {
     return factory(url.parse(links.prev, true).query, options);
   };
 
   /**
    * Get the next page.  If there is no next page, `next` will be `null`.
-   * @param {Object} options Any request options.
    * @return {Promise.<module:planet-client/api/page~Page>} The next page.
    * @method
    */
-  this.next = !links.next ? null : function(options) {
+  this.next = !links.next ? null : function() {
     return factory(url.parse(links.next, true).query, options);
   };
 

--- a/api/quads.js
+++ b/api/quads.js
@@ -50,7 +50,7 @@ function search(mosaicId, query, options) {
     terminator: options.terminator
   };
   return request.get(config).then(function(res) {
-    return new Page(res.body, search.bind(null, mosaicId));
+    return new Page(res.body, search.bind(null, mosaicId), options);
   });
 }
 

--- a/api/scenes.js
+++ b/api/scenes.js
@@ -64,7 +64,7 @@ function search(query, options) {
     terminator: options.terminator
   };
   return request.get(config).then(function(res) {
-    return new Page(res.body, search);
+    return new Page(res.body, search, options);
   });
 }
 

--- a/test/api/page.test.js
+++ b/test/api/page.test.js
@@ -63,11 +63,11 @@ describe('api/page', function() {
         }
       };
 
-      var page = new Page(data, spy);
+      var options = {};
+      var page = new Page(data, spy, options);
       assert.typeOf(page.next, 'function');
 
-      var options = {};
-      page.next(options);
+      page.next();
       assert.equal(spy.callCount, 1);
       var call = spy.getCall(0);
       assert.equal(call.args[1], options);
@@ -124,11 +124,11 @@ describe('api/page', function() {
         }
       };
 
-      var page = new Page(data, spy);
+      var options = {};
+      var page = new Page(data, spy, options);
       assert.typeOf(page.prev, 'function');
 
-      var options = {};
-      page.prev(options);
+      page.prev();
       assert.equal(spy.callCount, 1);
       var call = spy.getCall(0);
       assert.equal(call.args[1], options);


### PR DESCRIPTION
Instead of making callers provide options to `page.next()` and `page.prev()`, this makes it so the options passed to the constructor are reused.

Fixes #20.
