### PR TITLE
Resolve URLs relative to location if defined

### DIFF
--- a/api/request.js
+++ b/api/request.js
@@ -29,7 +29,18 @@ var defaultHeaders = {
  * @private
  */
 function parseConfig(config) {
-  var base = config.url ? url.parse(config.url, true) : {query: {}};
+  var base;
+  if (config.url) {
+    var resolved;
+    if (typeof location !== 'undefined') {
+      resolved = url.resolve(location.href, config.url);
+    } else {
+      resolved = config.url;
+    }
+    base = url.parse(resolved, true);
+  } else {
+    base = {query: {}};
+  }
   if (config.query) {
     config.path = url.format({
       pathname: base.pathname || config.pathname || '/',

--- a/test/api/request.test.js
+++ b/test/api/request.test.js
@@ -449,6 +449,14 @@ describe('api/request', function() {
     var parseConfig = req.parseConfig;
     var defaultHeaders = {accept: 'application/json'};
 
+    var existingLocation;
+    beforeEach(function() {
+      existingLocation = global.location;
+    });
+    afterEach(function() {
+      global.location = existingLocation;
+    });
+
     it('generates request options from a URL', function() {
       var config = {
         url: 'http://example.com'
@@ -459,6 +467,48 @@ describe('api/request', function() {
         port: '80',
         method: 'GET',
         path: '/',
+        headers: defaultHeaders
+      };
+
+      assert.deepEqual(parseConfig(config), options);
+    });
+
+    it('resolves a relative URL if location is defined', function() {
+      global.location = {
+        href: 'http://example.com/foo/bar.html'
+      };
+
+      var config = {
+        url: './relative/path/to/data.json'
+      };
+
+      var options = {
+        protocol: 'http:',
+        hostname: 'example.com',
+        port: '80',
+        method: 'GET',
+        path: '/foo/relative/path/to/data.json',
+        headers: defaultHeaders
+      };
+
+      assert.deepEqual(parseConfig(config), options);
+    });
+
+    it('works for root relative URLs', function() {
+      global.location = {
+        href: 'http://example.com/foo/bar.html'
+      };
+
+      var config = {
+        url: '/root/path/to/data.json'
+      };
+
+      var options = {
+        protocol: 'http:',
+        hostname: 'example.com',
+        port: '80',
+        method: 'GET',
+        path: '/root/path/to/data.json',
         headers: defaultHeaders
       };
 


### PR DESCRIPTION
This adds a bit of convenience for browser based clients.  Where `location.href` is defined, request methods can be called with a relative URL.  Node based clients need to use absolute URLs.
