### PR TITLE
Treat client errors

### DIFF
--- a/api/errors.js
+++ b/api/errors.js
@@ -122,9 +122,23 @@ function AbortedRequest(message) {
 AbortedRequest.prototype = new Error();
 AbortedRequest.prototype.name = 'AbortedRequest';
 
+/**
+ * An error generated on the client side, before issuing a request.
+ * @param {string} message Error message.
+ * @constructor
+ * @ignore
+ */
+function ClientError(message) {
+  this.message = message;
+  this.stack = (new Error()).stack;
+}
+ClientError.prototype = new Error();
+ClientError.prototype.name = 'ClientError';
+
 exports.ResponseError = ResponseError;
 exports.BadRequest = BadRequest;
 exports.Unauthorized = Unauthorized;
 exports.Forbidden = Forbidden;
 exports.UnexpectedResponse = UnexpectedResponse;
 exports.AbortedRequest = AbortedRequest;
+exports.ClientError = ClientError;

--- a/api/request.js
+++ b/api/request.js
@@ -242,6 +242,9 @@ function request(config) {
   return new Promise(function(resolve, reject) {
     var handler = createResponseHandler(resolve, reject, info);
     var client = protocol.request(options, handler);
+    client.on('error', function(err) {
+      reject(new errors.ClientError(err.message));
+    });
     if (config.body) {
       client.write(JSON.stringify(config.body));
     }

--- a/test/api/aois.test.js
+++ b/test/api/aois.test.js
@@ -5,6 +5,7 @@ var http = require('http');
 var https = require('https');
 var sinon = require('sinon');
 var stream = require('readable-stream');
+var createMockRequest = require('../util').createMockRequest;
 
 var request = require('../../api/request');
 var aois = require('../../api/aois');
@@ -47,11 +48,7 @@ describe('api/aois', function() {
   describe('create()', function() {
 
     beforeEach(function() {
-      mockRequest = {
-        write: sinon.spy(),
-        end: sinon.spy(),
-        abort: sinon.spy()
-      };
+      mockRequest = createMockRequest();
       http.request = sinon.spy(function() {
         return mockRequest;
       });

--- a/test/api/auth.test.js
+++ b/test/api/auth.test.js
@@ -7,6 +7,7 @@ var stream = require('readable-stream');
 var assert = require('chai').assert;
 var sinon = require('sinon');
 
+var createMockRequest = require('../util').createMockRequest;
 var auth = require('../../api/auth');
 var authStore = require('../../api/auth-store');
 var errors = require('../../api/errors');
@@ -22,11 +23,7 @@ describe('api/auth', function() {
       'XktYXBpLWtleSJ9.sYcuJzdUThIsvJGNymbobOh-nY6ZKFEqXTqwZS-4QvE';
 
   beforeEach(function() {
-    mockRequest = {
-      write: sinon.spy(),
-      end: sinon.spy(),
-      abort: sinon.spy()
-    };
+    mockRequest = createMockRequest();
     http.request = sinon.spy(function() {
       return mockRequest;
     });

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,12 @@
+var spy = require('sinon').spy;
+
+function createMockRequest() {
+  return {
+    write: spy(),
+    end: spy(),
+    abort: spy(),
+    on: spy()
+  };
+}
+
+exports.createMockRequest = createMockRequest;


### PR DESCRIPTION
If an error was generated by the xhr client, it was not getting caught / treated. 
