### PR TITLE
Use stream-http instead of browserify-http

### DIFF
--- a/api/request.js
+++ b/api/request.js
@@ -55,14 +55,6 @@ function parseConfig(config) {
   }
   config = assign(base, config);
 
-  // TODO: fix default port handling in http-browserify
-  var defaultPort;
-  if (config.protocol && config.protocol.indexOf('https') === 0) {
-    defaultPort = '443';
-  } else {
-    defaultPort = '80';
-  }
-
   var headers = assign({}, defaultHeaders);
   for (var key in config.headers) {
     headers[key.toLowerCase()] = config.headers[key];
@@ -89,11 +81,14 @@ function parseConfig(config) {
   var options = {
     protocol: config.protocol,
     hostname: config.hostname,
-    port: config.port || defaultPort,
     method: config.method || 'GET',
     path: config.path,
     headers: headers
   };
+
+  if (config.port) {
+    options.port = config.port;
+  }
 
   if ('withCredentials' in config) {
     options.withCredentials = config.withCredentials;
@@ -256,15 +251,7 @@ function request(config) {
     if (config.terminator) {
       config.terminator(function() {
         if (!info.aborted && !info.completed) {
-
           info.aborted = true;
-          if (client.abort) {
-            client.abort();
-          } else if (client.xhr && client.xhr.abort) {
-            // TODO: file a http-browserify issue for lack of abort
-            client.xhr.abort();
-          }
-
           reject(new errors.AbortedRequest('Request aborted'));
         }
       });

--- a/bin/planet.js
+++ b/bin/planet.js
@@ -83,9 +83,12 @@ function runner(commandName) {
     auth.setKey(options.key);
     command.main(options).then(function(output) {
       if (output) {
-        process.stdout.write(output);
+        process.stdout.write(output, function() {
+          process.exit(0);
+        });
+      } else {
+        process.exit(0);
       }
-      process.exit(0);
     }).catch(function(err) {
       log.error(err.message);
       if (err instanceof errors.ResponseError) {

--- a/cli/find-scenes.js
+++ b/cli/find-scenes.js
@@ -132,18 +132,18 @@ function resolveQuery(opts) {
 }
 
 /**
- * Recursively fetch all pages until the limit is reached.
+ * Recursively request all pages until the limit is reached.
  * @param {Promise.<module:planet-client/api/page~Page>} promise A promise that
  *     resolves to a page of scenes.
  * @param {Array} features An array of scene metadata.
  * @param {number} limit The limit.
  * @return {Promise.<Array>} An array that resolves to an array of scenes.
  */
-function fetch(promise, features, limit) {
+function keepRequesting(promise, features, limit) {
   return promise.then(function(page) {
     features = features.concat(page.data.features);
     if (page.next && features.length < limit) {
-      return fetch(page.next(), features, limit);
+      return keepRequesting(page.next(), features, limit);
     } else {
       if (features.length > limit) {
         features.length = limit;
@@ -163,7 +163,7 @@ function main(opts) {
   return resolveQuery(opts)
     .then(function(query) {
       log.debug('query: %j', query);
-      return fetch(scenes.search(query), [], opts.limit);
+      return keepRequesting(scenes.search(query), [], opts.limit);
     }).then(function(features) {
       return JSON.stringify({
         type: 'FeatureCollection',
@@ -206,7 +206,7 @@ exports.description = 'Find scenes';
 exports.main = main;
 exports.options = options;
 
-exports.fetch = fetch;
+exports.keepRequesting = keepRequesting;
 exports.parseAcquired = parseAcquired;
 exports.parseWhere = parseWhere;
 exports.resolveIntersects = resolveIntersects;

--- a/examples/find-mosaics.js
+++ b/examples/find-mosaics.js
@@ -7,17 +7,17 @@ planet.auth.setKey(process.env.PL_API_KEY);
 var mosaics = [];
 var limit = 500;
 
-function fetch(promise) {
+function keepRequesting(promise) {
   return promise.then(function(page) {
     mosaics = mosaics.concat(page.data.mosaics);
     console.log('got ' + mosaics.length + ' mosaics');
     if (page.next && mosaics.length < limit) {
-      return fetch(page.next());
+      return keepRequesting(page.next());
     }
   });
 }
 
-fetch(planet.mosaics.search())
+keepRequesting(planet.mosaics.search())
   .then(function() {
     console.log('done fetching');
   }).catch(function(err) {

--- a/examples/find-scenes-more.js
+++ b/examples/find-scenes-more.js
@@ -13,17 +13,17 @@ var query = {
 var scenes = [];
 var limit = 500;
 
-function fetch(promise) {
+function keepRequesting(promise) {
   return promise.then(function(page) {
     scenes = scenes.concat(page.data.features);
     console.log('got ' + scenes.length + ' scenes');
     if (page.next && scenes.length < limit) {
-      return fetch(page.next());
+      return keepRequesting(page.next());
     }
   });
 }
 
-fetch(planet.scenes.search(query))
+keepRequesting(planet.scenes.search(query))
   .then(function() {
     console.log('done fetching');
   }).catch(function(err) {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     ]
   },
   "devDependencies": {
-    "browserify": "^7.0.3",
+    "browserify": "^11.2.0",
     "chai": "^3.0.0",
     "coveralls": "^2.11.3",
     "envify": "^3.2.0",

--- a/test/api/request.test.js
+++ b/test/api/request.test.js
@@ -69,7 +69,6 @@ describe('api/request', function() {
       assert.deepEqual(call.args[0], {
         protocol: 'http:',
         hostname: 'example.com',
-        port: '80',
         method: 'GET',
         path: '/',
         headers: {accept: 'application/json'}
@@ -342,29 +341,6 @@ describe('api/request', function() {
         done(new Error('Expected promise to be rejected'));
       }).catch(function(err) {
         assert.instanceOf(err, errors.AbortedRequest);
-        assert.equal(mockRequest.abort.callCount, 1);
-        done();
-      });
-    });
-
-    it('calls request.xhr.abort() if request.abort is absent', function(done) {
-      var promise = request({
-        url: 'http//example.com',
-        terminator: function(abort) {
-          setTimeout(abort, 10);
-        }
-      });
-
-      delete mockRequest.abort;
-      mockRequest.xhr = {
-        abort: sinon.spy()
-      };
-
-      promise.then(function() {
-        done(new Error('Expected promise to be rejected'));
-      }).catch(function(err) {
-        assert.instanceOf(err, errors.AbortedRequest);
-        assert.equal(mockRequest.xhr.abort.callCount, 1);
         done();
       });
     });
@@ -387,7 +363,6 @@ describe('api/request', function() {
       }).catch(function(err) {
         rejected = true;
         assert.instanceOf(err, errors.AbortedRequest);
-        assert.equal(mockRequest.abort.callCount, 1);
       });
 
       assert.equal(http.request.callCount, 1);
@@ -484,7 +459,6 @@ describe('api/request', function() {
       var options = {
         protocol: 'http:',
         hostname: 'example.com',
-        port: '80',
         method: 'GET',
         path: '/',
         headers: defaultHeaders
@@ -516,7 +490,6 @@ describe('api/request', function() {
         var options = {
           protocol: 'http:',
           hostname: 'example.com',
-          port: '80',
           method: 'GET',
           path: '/foo/relative/path/to/data.json',
           headers: defaultHeaders
@@ -533,7 +506,6 @@ describe('api/request', function() {
         var options = {
           protocol: 'http:',
           hostname: 'example.com',
-          port: '80',
           method: 'GET',
           path: '/root/path/to/data.json',
           headers: defaultHeaders
@@ -554,26 +526,9 @@ describe('api/request', function() {
       var options = {
         protocol: 'http:',
         hostname: 'example.com',
-        port: '80',
         method: 'GET',
         path: '/',
         headers: util.assign({}, defaultHeaders, config.headers)
-      };
-
-      assert.deepEqual(parseConfig(config), options);
-    });
-
-    it('uses the correct default port for https', function() {
-      var config = {
-        url: 'https://example.com'
-      };
-      var options = {
-        protocol: 'https:',
-        hostname: 'example.com',
-        port: '443',
-        method: 'GET',
-        path: '/',
-        headers: defaultHeaders
       };
 
       assert.deepEqual(parseConfig(config), options);
@@ -586,7 +541,6 @@ describe('api/request', function() {
       var options = {
         protocol: 'https:',
         hostname: 'example.com',
-        port: '443',
         method: 'GET',
         path: '/page/1?foo=bar',
         headers: defaultHeaders
@@ -628,7 +582,6 @@ describe('api/request', function() {
       var options = {
         protocol: 'http:',
         hostname: 'example.com',
-        port: '80',
         method: 'POST',
         path: '/page',
         headers: headers
@@ -644,7 +597,6 @@ describe('api/request', function() {
       var options = {
         protocol: 'http:',
         hostname: 'example.com',
-        port: '80',
         method: 'GET',
         path: '/page?foo=bar',
         headers: defaultHeaders
@@ -663,7 +615,6 @@ describe('api/request', function() {
       var options = {
         protocol: 'http:',
         hostname: 'example.com',
-        port: '80',
         method: 'GET',
         path: '/page?foo=bar%20bam',
         headers: defaultHeaders
@@ -682,7 +633,6 @@ describe('api/request', function() {
       var options = {
         protocol: 'http:',
         hostname: 'example.com',
-        port: '80',
         method: 'GET',
         path: '/page?foo=bar&bam=baz',
         headers: defaultHeaders
@@ -701,7 +651,6 @@ describe('api/request', function() {
       var options = {
         protocol: 'http:',
         hostname: 'example.com',
-        port: '80',
         method: 'GET',
         path: '/?foo=bam',
         headers: defaultHeaders
@@ -718,7 +667,6 @@ describe('api/request', function() {
       var options = {
         protocol: 'http:',
         hostname: 'example.com',
-        port: '80',
         method: 'GET',
         path: '/',
         headers: defaultHeaders,

--- a/test/cli/find-scenes.test.js
+++ b/test/cli/find-scenes.test.js
@@ -8,7 +8,7 @@ var util = require('../../cli/util');
 
 describe('cli/find-scenes', function() {
 
-  describe('fetch()', function() {
+  describe('keepRequesting()', function() {
 
     var numPages = 10;
     var fetched = 0;
@@ -36,7 +36,7 @@ describe('cli/find-scenes', function() {
     it('concatenates pages of features', function(done) {
       var promise = Promise.resolve(makePage());
 
-      findScenes.fetch(promise, [], 100).then(function(features) {
+      findScenes.keepRequesting(promise, [], 100).then(function(features) {
         assert.lengthOf(features, 20);
         done();
       }).catch(done);
@@ -45,7 +45,7 @@ describe('cli/find-scenes', function() {
     it('stops when the limit is reached', function(done) {
       var promise = Promise.resolve(makePage());
 
-      findScenes.fetch(promise, [], 11).then(function(features) {
+      findScenes.keepRequesting(promise, [], 11).then(function(features) {
         assert.lengthOf(features, 11);
         done();
       }).catch(done);

--- a/test/util.js
+++ b/test/util.js
@@ -4,7 +4,6 @@ function createMockRequest() {
   return {
     write: spy(),
     end: spy(),
-    abort: spy(),
     on: spy()
   };
 }


### PR DESCRIPTION
This upgrade to Browserify makes it so `require('http')` is implemented by [`stream-http`](https://github.com/jhiesey/stream-http) rather than [`http-browserify`](https://github.com/substack/http-browserify).

The change includes the removal of a workaround for `http-browserify`'s port handling with HTTPS.  This means that anyone using the new version of `planet-client` must also use [Browserify >= 11](https://github.com/substack/node-browserify/blob/master/changelog.markdown#1100).
