### PR TITLE
Persist provider when paging

### DIFF
--- a/api/scenes.js
+++ b/api/scenes.js
@@ -64,7 +64,10 @@ function search(query, options) {
     terminator: options.terminator
   };
   return request.get(config).then(function(res) {
-    return new Page(res.body, search, options);
+    return new Page(res.body, function(pageQuery, opts) {
+      pageQuery.type = type;
+      return search(pageQuery, opts);
+    }, options);
   });
 }
 

--- a/test/api/scenes.test.js
+++ b/test/api/scenes.test.js
@@ -168,6 +168,38 @@ describe('api/scenes', function() {
       }).catch(done);
     });
 
+    it('maintains the provider when paging', function(done) {
+      var calls = [];
+      var provider = 'landsat';
+
+      request.get = function(config) {
+        calls.push(config);
+        return Promise.resolve({
+          body: {
+            features: [scene],
+            links: {
+              next: 'http://example.com/foo/'
+            }
+          }
+        });
+      };
+
+      var query = {
+        'acquired.lte': new Date().toISOString(),
+        type: provider
+      };
+
+      var promise = scenes.search(query);
+
+      promise.then(function(page) {
+        page.next().then(function(nextPage) {
+          assert.lengthOf(calls, 2);
+          assert.equal(calls[1].url, urls.join(SCENES, provider, ''));
+          done();
+        }).catch(done);
+      }).catch(done);
+    });
+
   });
 
 });


### PR DESCRIPTION
Without this change, if querying for scenes from a provider other than `ortho`, the provider would revert back to `ortho` past the first page. 
