### PR TITLE
Support for limit in queries

### DIFF
--- a/api/items.js
+++ b/api/items.js
@@ -44,6 +44,8 @@ function get(type, id, options) {
  *     previously saved search.
  * @param {Object} options.query An object with optional `_page_size` and
  *     `_sort` parameters.
+ * @param {number} options.limit Limit the result set to this size (by default,
+ *     no limit is applied).
  * @param {function(Array)} options.each A function that is called once for
  *     each page of data.  If the `each` callback is absent, all data will be
  *     concatenated and provided when the promise resolves.
@@ -59,6 +61,7 @@ function search(options) {
   options = options || {};
   var config = {
     query: options.query,
+    limit: options.limit,
     terminator: options.terminator
   };
   if (options.filter && options.types) {

--- a/api/pager.js
+++ b/api/pager.js
@@ -1,6 +1,7 @@
 var request = require('./request');
 
 module.exports = function(config, key, each) {
+  var limit = 'limit' in config ? config.limit : Infinity;
   var aborted = false;
   var terminator = config.terminator;
   config.terminator = function(abort) {
@@ -13,6 +14,7 @@ module.exports = function(config, key, each) {
   };
 
   return new Promise(function(resolve, reject) {
+    var count = 0;
     var all;
     if (!each) {
       each = function(array) {
@@ -26,6 +28,11 @@ module.exports = function(config, key, each) {
 
     function handler(response) {
       var data = response.body[key];
+      count += data.length;
+      if (count > limit) {
+        data.length = data.length - (count - limit);
+        aborted = true;
+      }
       each(data);
       if (!aborted) {
         var links = response.body._links || {};

--- a/api/searches.js
+++ b/api/searches.js
@@ -38,6 +38,8 @@ function get(id, options) {
  * @param {function(Array)} options.each A function that is called once for
  *     each page of data.  If the `each` callback is absent, all data will be
  *     concatenated and provided when the promise resolves.
+ * @param {number} options.limit Limit the result set to this size (by default,
+ *     no limit is applied).
  * @param {function(function())} options.terminator A function that is called
  *     with a function that can be called back to terminate the request.
  * @return {Promise<Array>} A promise that resolves when all data is finished
@@ -52,6 +54,7 @@ function search(options) {
   var config = {
     url: urls.searches(),
     query: query,
+    limit: options.limit,
     terminator: options.terminator
   };
   return pager(config, 'searches', options.each);

--- a/examples/quick-search.js
+++ b/examples/quick-search.js
@@ -1,9 +1,5 @@
 const planet = require('./planet');
 
-const limit = 150;
-let total = 0;
-let abort;
-
 const {and, range} = planet.filter;
 
 planet.items
@@ -16,15 +12,9 @@ planet.items
     query: {
       _page_size: 100
     },
-    terminator: terminate => abort = terminate,
+    limit: 150,
     each: items => {
-      const count = items.length;
-      console.log(`got ${count} items`);
-      total += count;
-      if (total >= limit) {
-        abort();
-        console.log('limit reached');
-      }
+      console.log(`got ${items.length} items`);
     }
   })
   .then(() => console.log('done'))

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   "devDependencies": {
     "browserify": "^14.1.0",
     "chai": "^3.5.0",
-    "eslint": "^3.18.0",
-    "eslint-config-planet": "13.0.0-beta.3",
+    "eslint": "^3.19.0",
+    "eslint-config-planet": "^13.0.1",
     "gh-pages": "^0.12.0",
     "handlebars": "^4.0.6",
     "in-publish": "^2.0.0",


### PR DESCRIPTION
The API doesn't support a `limit` on queries, so this provides a workaround for that.