### PR TITLE
Set the default limit when retrieving saved searches to 10

### DIFF
--- a/api/pager.js
+++ b/api/pager.js
@@ -1,7 +1,7 @@
 var request = require('./request');
 
 module.exports = function(config, key, each) {
-  var limit = 'limit' in config ? config.limit : Infinity;
+  var limit = 'limit' in config ? config.limit : 10;
   var pageSize = config.query && config.query._page_size;
 
   var aborted = false;

--- a/api/pager.js
+++ b/api/pager.js
@@ -1,7 +1,7 @@
 var request = require('./request');
 
 module.exports = function(config, key, each) {
-  var limit = 'limit' in config ? config.limit : 10;
+  var limit = 'limit' in config ? config.limit : Infinity;
   var pageSize = config.query && config.query._page_size;
 
   var aborted = false;

--- a/api/searches.js
+++ b/api/searches.js
@@ -54,7 +54,7 @@ function search(options) {
   var config = {
     url: urls.searches(),
     query: query,
-    limit: options.limit,
+    limit: 'limit' in options ? options.limit : 10,
     terminator: options.terminator
   };
   return pager(config, 'searches', options.each);


### PR DESCRIPTION
This mirrors https://github.com/planetlabs/planet-client-python/pull/178. This pull request would allow for sane display limits for saved searches in a terminal, Explorer, or other application.