### PR TITLE
rollback jwt-decode version to fix error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2453,9 +2453,9 @@
       "dev": true
     },
     "jwt-decode": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
-      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
+      "integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk="
     },
     "klaw": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "watchify": "^4.0.0"
   },
   "dependencies": {
-    "jwt-decode": "^3.1.2",
+    "jwt-decode": "^2.2.0",
     "xhr2": "^0.2.0"
   }
 }


### PR DESCRIPTION
In my eagerness to update dependencies jwt-decode was updated to v3 and that introduced breaking changes. This roll backs to v2 while I find the time to figure out why it broke. 